### PR TITLE
Add option to delete users and fix missing function in FakeUserRepository for tests

### DIFF
--- a/src/Contracts/UserRepository.php
+++ b/src/Contracts/UserRepository.php
@@ -34,4 +34,11 @@ interface UserRepository
      * @return Collection Keyed by email, containing an object for each user.
      */
     public function getByEmails(Collection $emails, array $fields = null): Collection;
+
+    /**
+     * Delete the user with given userID from the Auth0 database
+     *
+     * @param mixed $id
+     */
+    public function delete($id);
 }

--- a/src/Facades/Users.php
+++ b/src/Facades/Users.php
@@ -10,6 +10,7 @@ use Marketredesign\MrdAuth0Laravel\Repository\Fakes\FakeUserRepository;
 
 /**
  * @method static object|null get($id)
+ * @method static void delete($id)
  * @method static Collection getByIds(Collection $ids, array $fields = null)
  * @method static Collection getByEmails(Collection $emails, array $fields = null)
  * @method static int fakeCount()

--- a/src/Repository/Fakes/FakeUserRepository.php
+++ b/src/Repository/Fakes/FakeUserRepository.php
@@ -99,6 +99,15 @@ class FakeUserRepository implements UserRepository
     /**
      * @inheritDoc
      */
+    public function delete($id)
+    {
+        $this->userIds->forget($id);
+        $this->userObjects->forget($id);
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function getByIds(Collection $ids, array $fields = null): Collection
     {
         return $ids->mapWithKeys(function ($id) {

--- a/src/Repository/Fakes/FakeUserRepository.php
+++ b/src/Repository/Fakes/FakeUserRepository.php
@@ -101,7 +101,10 @@ class FakeUserRepository implements UserRepository
      */
     public function delete($id)
     {
-        $this->userIds->forget($id);
+        $this->userIds = $this->userIds->filter(function ($userID) use ($id){
+            return $userID != $id;
+        });
+
         $this->userObjects->forget($id);
     }
 

--- a/src/Repository/Fakes/FakeUserRepository.php
+++ b/src/Repository/Fakes/FakeUserRepository.php
@@ -115,6 +115,8 @@ class FakeUserRepository implements UserRepository
      */
     public function getByEmails(Collection $emails, array $fields = null): Collection
     {
-        throw new Exception('Not implemented for tests.');
+        return $this->userObjects->filter(function(Object $user) use ($emails){
+            return $emails->contains($user->email);
+        });
     }
 }

--- a/src/Repository/Fakes/FakeUserRepository.php
+++ b/src/Repository/Fakes/FakeUserRepository.php
@@ -101,7 +101,7 @@ class FakeUserRepository implements UserRepository
      */
     public function delete($id)
     {
-        $this->userIds = $this->userIds->filter (function($userID) use ($id) {
+        $this->userIds = $this->userIds->filter(function($userID) use ($id) {
             return $userID != $id;
         });
 

--- a/src/Repository/Fakes/FakeUserRepository.php
+++ b/src/Repository/Fakes/FakeUserRepository.php
@@ -101,7 +101,7 @@ class FakeUserRepository implements UserRepository
      */
     public function delete($id)
     {
-        $this->userIds = $this->userIds->filter(function ($userID) use ($id){
+        $this->userIds = $this->userIds->filter (function($userID) use ($id) {
             return $userID != $id;
         });
 
@@ -127,7 +127,7 @@ class FakeUserRepository implements UserRepository
      */
     public function getByEmails(Collection $emails, array $fields = null): Collection
     {
-        return $this->userObjects->filter(function(Object $user) use ($emails){
+        return $this->userObjects->filter(function (Object $user) use ($emails) {
             return $emails->contains($user->email);
         });
     }

--- a/src/Repository/Fakes/FakeUserRepository.php
+++ b/src/Repository/Fakes/FakeUserRepository.php
@@ -101,7 +101,7 @@ class FakeUserRepository implements UserRepository
      */
     public function delete($id)
     {
-        $this->userIds = $this->userIds->filter(function($userID) use ($id) {
+        $this->userIds = $this->userIds->filter(function ($userID) use ($id) {
             return $userID != $id;
         });
 

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -57,6 +57,19 @@ class UserRepository implements \Marketredesign\MrdAuth0Laravel\Contracts\UserRe
     }
 
     /**
+     * @inheritDoc
+     */
+    public function delete($id)
+    {
+        if ($id == null) {
+            return null;
+        }
+
+        $this->mgmtApi->users()->delete($id);
+    }
+
+
+    /**
      * Retrieves a collection of users from the Auth0 management API, queried on the given queryField looking for users
      * with the given queryValues. The result is optionally limited to only contain the given fields. The returned
      * collection will be keyed by the queryField.

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class UserRepository implements \Marketredesign\MrdAuth0Laravel\Contracts\UserRepository
 {
@@ -65,7 +66,10 @@ class UserRepository implements \Marketredesign\MrdAuth0Laravel\Contracts\UserRe
             return null;
         }
 
-        $this->mgmtApi->users()->delete($id);
+        $response = $this->mgmtApi->users()->delete($id);
+        if ($response->getStatusCode() != 204) {
+            throw new HttpException($response->getStatusCode());
+        }
     }
 
 

--- a/tests/Feature/UserFacadeTest.php
+++ b/tests/Feature/UserFacadeTest.php
@@ -177,4 +177,20 @@ class UserFacadeTest extends TestCase
         // Assert it returns the correct user,
         self::assertContains(1, $users->keys());
     }
+
+    /**
+     * Verifies that the fake delete functionality properly deletes users from the fake repository
+     */
+    public function testFakeDelete()
+    {
+        Users::fake();
+
+        Users::fakeAddUsers(collect(['test', 'sjaak', 'user2']));
+        Users::delete('sjaak');
+
+        $users = Users::getByIds(collect(['test', 'sjaak', 'user2']));
+        self::assertEquals(2, $users->count());
+        self::assertContains('test', $users->keys());
+        self::assertContains('user2', $users->keys());
+    }
 }

--- a/tests/Feature/UserFacadeTest.php
+++ b/tests/Feature/UserFacadeTest.php
@@ -156,4 +156,25 @@ class UserFacadeTest extends TestCase
         // Verify users have different fields.
         self::assertNotEquals($users->get('sjaak')->email, $users->get('user2')->email);
     }
+
+    /**
+     * Verifies that users can be retrieved through email address from the fake repository
+     */
+    public function testFakeGetByEmails()
+    {
+        // Enable testing mode
+        Users::fake();
+
+        // Add a fake user to the repository
+        Users::fakeAddUsers(collect(1));
+
+        // Get email of user
+        $email = collect(Users::get(1)->email);
+
+        // Get the users through email
+        $users = Users::getByEmails($email);
+
+        // Assert it returns the correct user,
+        self::assertContains(1, $users->keys());
+    }
 }

--- a/tests/Feature/UserRepositoryTest.php
+++ b/tests/Feature/UserRepositoryTest.php
@@ -103,7 +103,7 @@ class UserRepositoryTest extends TestCase
     }
 
     /**
-     * Verifies that retrieving an single, existing user works as expected.
+     * Verifies that retrieving a single, existing user works as expected.
      */
     public function testGetExisting()
     {
@@ -720,5 +720,27 @@ class UserRepositoryTest extends TestCase
 
         // Verify now a total of two api calls was made.
         self::assertCount(2, $this->guzzleContainer);
+    }
+
+    /**
+     * Verifies that deletion works correctly
+     */
+    public function testDeleteOne()
+    {
+        // Altered response from Auth0 API documentation
+        $this->mockedResponses = [new Response(200, [], '')];
+
+        // Call function under test.
+        $userID = 'test';
+        $response = $this->repo->delete($userID);
+
+        // Find the request that was sent to Auth0
+        $request = $this->guzzleContainer[0]['request'];
+
+        // Expect 1 api call.
+        self::assertCount(1, $this->guzzleContainer);
+
+        // Verify correct endpoint was called.
+        self::assertEquals('/api/v2/users/' . $userID, $request->getUri()->getPath());
     }
 }

--- a/tests/Feature/UserRepositoryTest.php
+++ b/tests/Feature/UserRepositoryTest.php
@@ -728,19 +728,22 @@ class UserRepositoryTest extends TestCase
     public function testDeleteOne()
     {
         // Altered response from Auth0 API documentation
-        $this->mockedResponses = [new Response(200, [], '')];
+        $this->mockedResponses = [new Response(204, [], '')];
 
-        // Call function under test.
+        // Call function under test
         $userID = 'test';
         $response = $this->repo->delete($userID);
 
         // Find the request that was sent to Auth0
         $request = $this->guzzleContainer[0]['request'];
 
-        // Expect 1 api call.
+        // Expect a Delete request
+        self::assertEquals("DELETE", $request->getMethod());
+
+        // Expect 1 api call
         self::assertCount(1, $this->guzzleContainer);
 
-        // Verify correct endpoint was called.
+        // Verify correct endpoint was called
         self::assertEquals('/api/v2/users/' . $userID, $request->getUri()->getPath());
     }
 }


### PR DESCRIPTION
## Proposed changes

Added support for the user deletion through the Auth0 Management API to both real and fake User facade. Furthermore added support for the `getByEmails` function in the fake Users facade. 

## Types of changes

What types of changes does your code introduce to this repository?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

### Unit testing

Run `vendor/bin/phpunit` from the project root

### Manual testing

Not Applicable 