### PR TITLE
User creation also fills in name property name now

### DIFF
--- a/src/Repository/Fakes/FakeUserRepository.php
+++ b/src/Repository/Fakes/FakeUserRepository.php
@@ -155,6 +155,7 @@ class FakeUserRepository implements UserRepository
         $userModel->email = $email;
         $userModel->family_name = $lastName;
         $userModel->given_name = $firstName;
+        $userModel->name = $firstName . ' ' . $lastName;
 
         return $userModel;
     }

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -84,6 +84,7 @@ class UserRepository implements \Marketredesign\MrdAuth0Laravel\Contracts\UserRe
             'email' => $email,
             'given_name' => $firstName,
             'family_name' => $lastName,
+            'name' => $firstName . ' ' . $lastName,
             // hash a random 16 character string to generate initial random password
             'password' => Hash::make(Str::random())
         ]);

--- a/tests/Feature/UserFacadeTest.php
+++ b/tests/Feature/UserFacadeTest.php
@@ -208,6 +208,7 @@ class UserFacadeTest extends TestCase
         self::assertEquals("foo@bar.com", $user->email);
         self::assertEquals("foo", $user->given_name);
         self::assertEquals("bar", $user->family_name);
+        self::assertEquals("foo" . " " . "bar", $user->name);
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

User creation only fills out the `given_name ` and `family_name` fields whereas it should also be filling out the `name` field, this PR remedies that.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

### Unit testing

Standard phpunit unit tests

