### PR TITLE
Update readme required php version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Wrapper to easily configure Auth0 with a Laravel application
 
 ### Prerequisites
 
-* PHP 7.3 or higher
+* PHP 7.4 or higher
 * PHP JSON extension
 * PHP mbstring extension
 * PHP XML extension


### PR DESCRIPTION
## Proposed changes

In #10, the required PHP version changed to 7.4 or higher. The README.me however still stated 7.3 or higher. This PR fixes that.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
### Unit testing
n/a

### Manual testing
Check the readme

## Further comments
