### PR TITLE
Add `managedOnly` parameter to user dataset retrieve functions

### DIFF
--- a/src/Contracts/DatasetRepository.php
+++ b/src/Contracts/DatasetRepository.php
@@ -12,16 +12,18 @@ interface DatasetRepository
     /**
      * Get all dataset IDs that the user in the current request has access to.
      *
+     * @param bool $managedOnly Only retrieve IDs of datasets that the user is a manager of.
      * @return Collection of dataset IDs.
      * @throws RequestException
      */
-    public function getUserDatasetIds(): Collection;
+    public function getUserDatasetIds(bool $managedOnly = false): Collection;
 
     /**
      * Get all datasets that the user in the current request has access to.
      *
+     * @param bool $managedOnly Only retrieve datasets that the user is a manager of.
      * @return ResourceCollection of datasets.
      * @throws RequestException
      */
-    public function getUserDatasets(): ResourceCollection;
+    public function getUserDatasets(bool $managedOnly = false): ResourceCollection;
 }

--- a/src/Facades/Datasets.php
+++ b/src/Facades/Datasets.php
@@ -10,11 +10,11 @@ use Marketredesign\MrdAuth0Laravel\Contracts\DatasetRepository;
 use Marketredesign\MrdAuth0Laravel\Repository\Fakes\FakeDatasetRepository;
 
 /**
- * @method static Collection getUserDatasetIds()
- * @method static ResourceCollection getUserDatasets()
- * @method static int fakeCount()
+ * @method static Collection getUserDatasetIds(bool $managedOnly = false)
+ * @method static ResourceCollection getUserDatasets(bool $managedOnly = false)
+ * @method static int fakeCount(bool $managedOnly = false)
  * @method static void fakeClear()
- * @method static void fakeAddDatasets(Collection $ids)
+ * @method static void fakeAddDatasets(Collection $ids, bool $isManager = false)
  *
  * @see DatasetRepository
  * @see FakeDatasetRepository

--- a/src/Repository/DatasetRepository.php
+++ b/src/Repository/DatasetRepository.php
@@ -75,9 +75,11 @@ class DatasetRepository implements \Marketredesign\MrdAuth0Laravel\Contracts\Dat
     /**
      * @inheritDoc
      */
-    public function getUserDatasetIds(): Collection
+    public function getUserDatasetIds(bool $managedOnly = false): Collection
     {
-        $datasets = collect($this->get('/datasets')->get('datasets'));
+        $datasets = collect(
+            $this->get('/datasets', ['query' => ['managed_only' => $managedOnly]])->get('datasets')
+        );
 
         return $datasets->pluck('id');
     }
@@ -85,9 +87,9 @@ class DatasetRepository implements \Marketredesign\MrdAuth0Laravel\Contracts\Dat
     /**
      * @inheritDoc
      */
-    public function getUserDatasets(): ResourceCollection
+    public function getUserDatasets(bool $managedOnly = false): ResourceCollection
     {
-        $datasets = $this->get('/datasets')->get('datasets');
+        $datasets = $this->get('/datasets', ['query' => ['managed_only' => $managedOnly]])->get('datasets');
 
         return DatasetResource::collection($datasets);
     }

--- a/src/Repository/Fakes/FakeDatasetRepository.php
+++ b/src/Repository/Fakes/FakeDatasetRepository.php
@@ -19,6 +19,11 @@ class FakeDatasetRepository implements DatasetRepository
     private $datasetIds;
 
     /**
+     * @var Collection Fake dataset IDs that the user is manager of.
+     */
+    private $managedDatasetIds;
+
+    /**
      * @var Collection Fake dataset objects, keyed by dataset ID.
      */
     private $datasets;
@@ -29,11 +34,16 @@ class FakeDatasetRepository implements DatasetRepository
     }
 
     /**
+     * @param bool $managedOnly Only count datasets that the user is manager of.
      * @return int Count number of datasets in the fake dataset repository.
      */
-    public function fakeCount(): int
+    public function fakeCount(bool $managedOnly = false): int
     {
-        return $this->datasetIds->count();
+        if ($managedOnly) {
+            return $this->managedDatasetIds->count();
+        } else {
+            return $this->datasetIds->count();
+        }
     }
 
     /**
@@ -42,6 +52,7 @@ class FakeDatasetRepository implements DatasetRepository
     public function fakeClear(): void
     {
         $this->datasetIds = collect();
+        $this->managedDatasetIds = collect();
         $this->datasets = collect();
         $this->setUpFaker();
     }
@@ -50,10 +61,15 @@ class FakeDatasetRepository implements DatasetRepository
      * Add collection of dataset IDs for which a random dataset object will be returned when the repository is queried.
      *
      * @param Collection $ids Dataset IDs the user has access to.
+     * @param bool $isManager Whether or not the user is manager of the given datasets.
      */
-    public function fakeAddDatasets(Collection $ids): void
+    public function fakeAddDatasets(Collection $ids, bool $isManager = false): void
     {
         $this->datasetIds = $this->datasetIds->concat($ids)->unique();
+
+        if ($isManager) {
+            $this->managedDatasetIds = $this->managedDatasetIds->concat($ids)->unique();
+        }
     }
 
     /**
@@ -83,17 +99,21 @@ class FakeDatasetRepository implements DatasetRepository
     /**
      * @inheritDoc
      */
-    public function getUserDatasetIds(): Collection
+    public function getUserDatasetIds(bool $managedOnly = false): Collection
     {
-        return $this->datasetIds;
+        if ($managedOnly) {
+            return $this->managedDatasetIds;
+        } else {
+            return $this->datasetIds;
+        }
     }
 
     /**
      * @inheritDoc
      */
-    public function getUserDatasets(): ResourceCollection
+    public function getUserDatasets(bool $managedOnly = false): ResourceCollection
     {
-        $datasets = $this->datasetIds->map(function ($datasetId) {
+        $datasets = $this->getUserDatasetIds($managedOnly)->map(function ($datasetId) {
             return $this->getOrCreateDatasetForId($datasetId);
         });
 

--- a/tests/Feature/DatasetFacadeTest.php
+++ b/tests/Feature/DatasetFacadeTest.php
@@ -74,6 +74,10 @@ class DatasetFacadeTest extends TestCase
             self::assertNotEmpty($dataset['created_at']);
             self::assertNotEmpty($dataset['updated_at']);
         }
+
+        // Verify no managed datasets.
+        self::assertEmpty(Datasets::getUserDatasetIds(true));
+        self::assertEmpty(Datasets::getUserDatasets(true));
     }
 
     /**
@@ -107,17 +111,23 @@ class DatasetFacadeTest extends TestCase
 
         // Add fake dataset to the repository.
         Datasets::fakeAddDatasets(collect([10]));
+        // Add fake managed dataset to the repository.
+        Datasets::fakeAddDatasets(collect([12]), true);
 
-        // Verify dataset exists.
+        // Verify datasets exist.
         self::assertContains(10, Datasets::getUserDatasetIds());
+        self::assertContains(12, Datasets::getUserDatasetIds(true));
         self::assertEquals(10, Datasets::getUserDatasets()->resolve()[0]['id']);
+        self::assertEquals(12, Datasets::getUserDatasets(true)->resolve()[0]['id']);
 
         // Now clear the repository.
         Datasets::fakeClear();
 
         // Verify dataset does not exist anymore.
         self::assertTrue(Datasets::getUserDatasetIds()->isEmpty());
+        self::assertTrue(Datasets::getUserDatasetIds(true)->isEmpty());
         self::assertEmpty(Datasets::getUserDatasets()->resolve());
+        self::assertEmpty(Datasets::getUserDatasets(true)->resolve());
     }
 
     /**
@@ -130,14 +140,18 @@ class DatasetFacadeTest extends TestCase
 
         // Add 3 fake datasets to the repository.
         Datasets::fakeAddDatasets(collect([4, 8, 12]));
+        // Add 2 additional repositories which the user is manager for.
+        Datasets::fakeAddDatasets(collect([5, 99]), true);
 
         // Verify count.
-        self::assertEquals(3, Datasets::fakeCount());
+        self::assertEquals(5, Datasets::fakeCount());
+        self::assertEquals(2, Datasets::fakeCount(true));
 
         // Now clear the repository.
         Datasets::fakeClear();
 
         // Verify count zero.
         self::assertEquals(0, Datasets::fakeCount());
+        self::assertEquals(0, Datasets::fakeCount(true));
     }
 }

--- a/tests/Feature/DatasetRepositoryTest.php
+++ b/tests/Feature/DatasetRepositoryTest.php
@@ -212,4 +212,28 @@ class DatasetRepositoryTest extends TestCase
             self::assertEquals("Bearer $token", $request->getHeader('Authorization')[0]);
         }
     }
+
+    /**
+     * Verifies that the `managed_only` query parameter is sent to the user tool when requesting datasets (or IDs).
+     */
+    public function testManagedOnlyParameter()
+    {
+        // Return empty response 4 times.
+        $response = new Response(200, [], '{"datasets": []}');
+        $this->mockedResponses = [$response, $response, $response, $response];
+
+        foreach ([false, true] as $i => $bool) {
+            // Call functions under test.
+            $this->repo->getUserDatasetIds($bool);
+            $this->repo->getUserDatasets($bool);
+
+            $boolBit = $bool ? 1 : 0;
+            // Find the requests that are made to the user tool.
+            $requestIds = $this->guzzleContainer[2 * $i]['request'];
+            $requestObjects = $this->guzzleContainer[2 * $i + 1]['request'];
+
+            self::assertEquals("managed_only=$boolBit", $requestIds->getUri()->getQuery());
+            self::assertEquals("managed_only=$boolBit", $requestObjects->getUri()->getQuery());
+        }
+    }
 }


### PR DESCRIPTION
## Proposed changes

In some cases it's useful to query which datasets the user can manage. PR  marketredesign/user_tool#23 adds this functionality to the API. This PR adds the option to the Facade / repository such that it can be used easily by users of this package.

Required for AB#24.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

### Unit testing
Added / updated.

### Manual testing
Try using the new option in a package. (dataset service PR that does this following)

## Further comments
n/a