### PR TITLE
Add support for `modules`, including improved faking

### DIFF
--- a/src/Http/Resources/DatasetResource.php
+++ b/src/Http/Resources/DatasetResource.php
@@ -22,6 +22,7 @@ class DatasetResource extends JsonResource
             'dss_url' => $this->dss_url,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
+            'modules' => $this->modules,
         ];
     }
 }

--- a/src/Repository/Fakes/FakeDatasetRepository.php
+++ b/src/Repository/Fakes/FakeDatasetRepository.php
@@ -81,7 +81,7 @@ class FakeDatasetRepository implements DatasetRepository
     }
 
     /**
-     * Gets the dataset object for the given ID or creates, stores and returns a random one if it doesn't already exist.
+     * Create and store a dataset. Any fields that are not provided are generated randomly.
      *
      * @param $dataset Collection Dataset to add, including at least the 'id' field.
      */

--- a/tests/Feature/DatasetFacadeTest.php
+++ b/tests/Feature/DatasetFacadeTest.php
@@ -34,9 +34,9 @@ class DatasetFacadeTest extends TestCase
     }
 
     /**
-     * Verifies testing mode with adding fake datasets.
+     * Verifies testing mode with adding fake datasets by collection of IDs.
      */
-    public function testFakeAddDatasets()
+    public function testFakeAddDatasetsById()
     {
         // Enable testing mode.
         Datasets::fake();
@@ -73,7 +73,87 @@ class DatasetFacadeTest extends TestCase
             self::assertNotEmpty($dataset['name']);
             self::assertNotEmpty($dataset['created_at']);
             self::assertNotEmpty($dataset['updated_at']);
+            self::assertArrayHasKey('modules', $dataset);
+            self::assertNotNull($dataset['modules']);
         }
+
+        // Verify no managed datasets.
+        self::assertEmpty(Datasets::getUserDatasetIds(true));
+        self::assertEmpty(Datasets::getUserDatasets(true));
+    }
+
+    /**
+     * Verifies testing mode with adding fake datasets by collection of collectionss.
+     */
+    public function testFakeAddDatasetsByCollections()
+    {
+        // Enable testing mode.
+        Datasets::fake();
+
+        // Initially expect no dataset access.
+        self::assertTrue(Datasets::getUserDatasetIds()->isEmpty());
+        self::assertEmpty(Datasets::getUserDatasets()->resolve());
+
+        // Add 3 fake datasets to the repository with varying levels of filled fields.
+        Datasets::fakeAddDatasets(collect([
+            collect([
+                'id' => 10,
+            ]),
+            collect([
+                'id' => 5,
+                'name' => 'A Dataset with ID 5',
+                'modules' => [],
+            ]),
+            collect([
+                'id' => 8,
+                'name' => 'Dataset #8',
+                'dss_url' => 'https://website.com',
+                'created_at' => '2022-05-17T15:02:59.000000Z',
+                'updated_at' => '2022-05-17T15:02:59.000000Z',
+                'modules' => ['module_A', 'another_module'],
+            ]),
+        ]));
+
+        // Retrieve dataset access.
+        $datasetIds = Datasets::getUserDatasetIds();
+        $datasets = collect(Datasets::getUserDatasets()->resolve());
+
+        // Verify correct number of datasets.
+        self::assertEquals(3, $datasetIds->count());
+        self::assertEquals(3, $datasets->count());
+
+        // Verify correct dataset IDs returned.
+        self::assertContains(10, $datasetIds);
+        self::assertContains(5, $datasetIds);
+        self::assertContains(8, $datasetIds);
+
+        // Find datasets in response.
+        $dataset10 = $datasets->firstWhere('id', 10);
+        $dataset5 = $datasets->firstWhere('id', 5);
+        $dataset8 = $datasets->firstWhere('id', 8);
+
+        // Verify the correct datasets are returned.
+        self::assertNotNull($dataset10);
+        self::assertNotNull($dataset5);
+        self::assertNotNull($dataset8);
+
+        // Verify the returned datasets have fake data.
+        foreach ([$dataset10, $dataset5, $dataset8] as $dataset) {
+            self::assertNotEmpty($dataset['name']);
+            self::assertNotEmpty($dataset['created_at']);
+            self::assertNotEmpty($dataset['updated_at']);
+            self::assertArrayHasKey('modules', $dataset);
+            self::assertNotNull($dataset['modules']);
+        }
+
+        // Verify the inputted fields are present in the response
+        self::assertEquals('A Dataset with ID 5', $dataset5['name']);
+        self::assertEquals([], $dataset5['modules']);
+        self::assertEquals('Dataset #8', $dataset8['name']);
+        self::assertEquals('https://website.com', $dataset8['dss_url']);
+        self::assertEquals('2022-05-17T15:02:59.000000Z', $dataset8['created_at']);
+        self::assertEquals('2022-05-17T15:02:59.000000Z', $dataset8['updated_at']);
+        self::assertEquals(['module_A', 'another_module'], $dataset8['modules']);
 
         // Verify no managed datasets.
         self::assertEmpty(Datasets::getUserDatasetIds(true));
@@ -89,8 +169,14 @@ class DatasetFacadeTest extends TestCase
         // Enable testing mode.
         Datasets::fake();
 
-        // Add 2 fake datasets to the repository.
+        // Add 2 fake datasets to the repository by IDs.
         Datasets::fakeAddDatasets(collect([10, 3]));
+
+        // Add 2 fake datasets to the repository by collections.
+        Datasets::fakeAddDatasets(collect([
+            collect(['id' => 8]),
+            collect(['id' => 12, 'name' => 'A dataset']),
+        ]));
 
         // Retrieve datasets twice
         $datasets1 = collect(Datasets::getUserDatasets()->resolve());
@@ -109,21 +195,28 @@ class DatasetFacadeTest extends TestCase
         // Enable testing mode.
         Datasets::fake();
 
-        // Add fake dataset to the repository.
-        Datasets::fakeAddDatasets(collect([10]));
-        // Add fake managed dataset to the repository.
+        // Add fake datasets to the repository by ID and collection.
+        Datasets::fakeAddDatasets(collect([9]));
+        Datasets::fakeAddDatasets(collect([collect(['id' => 10])]));
+        // Add fake managed datasets to the repository by ID and collection.
         Datasets::fakeAddDatasets(collect([12]), true);
+        Datasets::fakeAddDatasets(collect([collect(['id' => 13])]), true);
 
         // Verify datasets exist.
+        self::assertContains(9, Datasets::getUserDatasetIds());
         self::assertContains(10, Datasets::getUserDatasetIds());
         self::assertContains(12, Datasets::getUserDatasetIds(true));
-        self::assertEquals(10, Datasets::getUserDatasets()->resolve()[0]['id']);
+        self::assertEquals(9, Datasets::getUserDatasets()->resolve()[0]['id']);
+        self::assertEquals(10, Datasets::getUserDatasets()->resolve()[1]['id']);
+        self::assertEquals(12, Datasets::getUserDatasets()->resolve()[2]['id']);
+        self::assertEquals(13, Datasets::getUserDatasets()->resolve()[3]['id']);
         self::assertEquals(12, Datasets::getUserDatasets(true)->resolve()[0]['id']);
+        self::assertEquals(13, Datasets::getUserDatasets(true)->resolve()[1]['id']);
 
         // Now clear the repository.
         Datasets::fakeClear();
 
-        // Verify dataset does not exist anymore.
+        // Verify datasets do not exist anymore.
         self::assertTrue(Datasets::getUserDatasetIds()->isEmpty());
         self::assertTrue(Datasets::getUserDatasetIds(true)->isEmpty());
         self::assertEmpty(Datasets::getUserDatasets()->resolve());
@@ -139,9 +232,11 @@ class DatasetFacadeTest extends TestCase
         Datasets::fake();
 
         // Add 3 fake datasets to the repository.
-        Datasets::fakeAddDatasets(collect([4, 8, 12]));
+        Datasets::fakeAddDatasets(collect([4, 8]));
+        Datasets::fakeAddDatasets(collect([collect(['id' => 12, 'name' => 'Sjaak'])]));
         // Add 2 additional repositories which the user is manager for.
-        Datasets::fakeAddDatasets(collect([5, 99]), true);
+        Datasets::fakeAddDatasets(collect([5]), true);
+        Datasets::fakeAddDatasets(collect([collect(['id' => 99, 'modules' => ['some_module']])]), true);
 
         // Verify count.
         self::assertEquals(5, Datasets::fakeCount());

--- a/tests/Feature/DatasetFacadeTest.php
+++ b/tests/Feature/DatasetFacadeTest.php
@@ -234,7 +234,7 @@ class DatasetFacadeTest extends TestCase
         // Add 3 fake datasets to the repository.
         Datasets::fakeAddDatasets(collect([4, 8]));
         Datasets::fakeAddDatasets(collect([collect(['id' => 12, 'name' => 'Sjaak'])]));
-        // Add 2 additional repositories which the user is manager for.
+        // Add 2 additional datasets which the user is manager for.
         Datasets::fakeAddDatasets(collect([5]), true);
         Datasets::fakeAddDatasets(collect([collect(['id' => 99, 'modules' => ['some_module']])]), true);
 

--- a/tests/Feature/DatasetRepositoryTest.php
+++ b/tests/Feature/DatasetRepositoryTest.php
@@ -47,7 +47,7 @@ class DatasetRepositoryTest extends TestCase
     protected function assertDataset(array $expDataset, ?array $actDataset)
     {
         self::assertNotNull($actDataset);
-        
+
         self::assertEquals($expDataset['name'], $actDataset['name']);
         self::assertEquals($expDataset['dss_url'], $actDataset['dss_url']);
 
@@ -142,10 +142,11 @@ class DatasetRepositoryTest extends TestCase
     {
         // Return mocked response as given by user tool.
         $this->mockedResponses = [new Response(200, [], '{"datasets":[{"id":7,"name":"Cool dataset",
-        "dss_url":"http://c.com","created_at":"2021-03-15T15:02:59.000000Z","updated_at":"2021-03-15T15:02:59.000000Z"},
-        {"id":6,"name":"Sjaak & Co","dss_url":null,"created_at":"2021-03-04T00:42:10.000000Z",
-        "updated_at":"2021-03-06T00:23:00.000060Z"},{"id":1,"name":"Spotify","dss_url": "https://spotify.com",
-        "created_at":"2020-11-10T17:09:16.000000Z","updated_at":"2020-12-10T18:09:22.000000Z"}]}')];
+        "dss_url":"http://c.com","created_at":"2021-03-15T15:02:59.000000Z","updated_at":"2021-03-15T15:02:59.000000Z",
+        "modules":[]},{"id":6,"name":"Sjaak & Co","dss_url":null,"created_at":"2021-03-04T00:42:10.000000Z",
+        "updated_at":"2021-03-06T00:23:00.000060Z","modules":["module_A"]},{"id":1,"name":"Spotify",
+        "dss_url": "https://spotify.com","created_at":"2020-11-10T17:09:16.000000Z",
+        "updated_at":"2020-12-10T18:09:22.000000Z","modules":[]}]}')];
 
         // Call function under test.
         $datasetIds = $this->repo->getUserDatasetIds();
@@ -165,10 +166,11 @@ class DatasetRepositoryTest extends TestCase
     {
         // Return mocked response as given by user tool.
         $this->mockedResponses = [new Response(200, [], '{"datasets":[{"id":7,"name":"Cool dataset",
-        "dss_url":"http://c.com","created_at":"2021-03-15T15:02:59.000000Z","updated_at":"2021-03-15T15:02:59.000000Z"},
-        {"id":6,"name":"Sjaak & Co","dss_url":null,"created_at":"2021-03-04T00:42:10.000000Z",
-        "updated_at":"2021-03-06T00:23:00.000060Z"},{"id":1,"name":"Spotify","dss_url": "https://spotify.com",
-        "created_at":"2020-11-10T17:09:16.000000Z","updated_at":"2020-12-10T18:09:22.000000Z"}]}')];
+        "dss_url":"http://c.com","created_at":"2021-03-15T15:02:59.000000Z","updated_at":"2021-03-15T15:02:59.000000Z",
+        "modules":[]},{"id":6,"name":"Sjaak & Co","dss_url":null,"created_at":"2021-03-04T00:42:10.000000Z",
+        "updated_at":"2021-03-06T00:23:00.000060Z","modules":["module_A","module_B"]},{"id":1,"name":"Spotify",
+        "dss_url": "https://spotify.com","created_at":"2020-11-10T17:09:16.000000Z",
+        "updated_at":"2020-12-10T18:09:22.000000Z","modules":["module_B","module_C"]}]}')];
 
         // Call function under test.
         $resourceCollection = $this->repo->getUserDatasets();
@@ -190,18 +192,21 @@ class DatasetRepositoryTest extends TestCase
             'dss_url' => 'https://spotify.com',
             'created_at' => '2020-11-10T17:09:16.000000Z',
             'updated_at' => '2020-12-10T18:09:22.000000Z',
+            'modules' => [],
         ], $dataset1);
         $this->assertDataset([
             'name' => 'Sjaak & Co',
             'dss_url' => null,
             'created_at' => '2021-03-04T00:42:10.000000Z',
             'updated_at' => '2021-03-06T00:23:00.000060Z',
+            'modules' => ['module_A', 'module_B'],
         ], $dataset6);
         $this->assertDataset([
             'name' => 'Cool dataset',
             'dss_url' => 'http://c.com',
             'created_at' => '2021-03-15T15:02:59.000000Z',
             'updated_at' => '2021-03-15T15:02:59.000000Z',
+            'modules' => ['module_B', 'module_C'],
         ], $dataset7);
     }
 
@@ -266,13 +271,14 @@ class DatasetRepositoryTest extends TestCase
 
         // Create 2 different fake responses, for 2 different users.
         $response1 = new Response(200, [], '{"datasets":[{"id":7,"name":"Cool dataset","dss_url":null,
-        "created_at":"2021-03-15T15:02:59.000000Z","updated_at":"2021-03-15T15:02:59.000000Z"},{"id":6,
+        "created_at":"2021-03-15T15:02:59.000000Z","updated_at":"2021-03-15T15:02:59.000000Z","modules":[]},{"id":6,
         "name":"Sjaak & Co","dss_url":null,"created_at":"2021-03-04T00:42:10.000000Z",
-        "updated_at":"2021-03-04T00:42:10.000000Z"},{"id":1,"name":"Spotify","dss_url":null,
-        "created_at":"2020-11-10T17:09:16.000000Z","updated_at":"2020-11-10T17:09:16.000000Z"}]}');
+        "updated_at":"2021-03-04T00:42:10.000000Z","modules":[]},{"id":1,"name":"Spotify","dss_url":null,
+        "created_at":"2020-11-10T17:09:16.000000Z","updated_at":"2020-11-10T17:09:16.000000Z","modules":[]}]}');
         $response2 = new Response(200, [], '{"datasets":[{"id":6,"name":"Sjaak & Co","dss_url":null,
-        "created_at":"2021-03-04T00:42:10.000000Z","updated_at":"2021-03-04T00:42:10.000000Z"},{"id":1,"name":"Spotify",
-        "dss_url":null,"created_at":"2020-11-10T17:09:16.000000Z","updated_at":"2020-11-10T17:09:16.000000Z"}]}');
+        "created_at":"2021-03-04T00:42:10.000000Z","updated_at":"2021-03-04T00:42:10.000000Z","modules":[]},{"id":1,
+        "name":"Spotify","dss_url":null,"created_at":"2020-11-10T17:09:16.000000Z",
+        "updated_at":"2020-11-10T17:09:16.000000Z","modules":[]}]}');
         $this->mockedResponses = [$response1, $response1, $response2, $response2, $response1, $response1];
 
         self::assertEquals([1,6,7], $this->repo->getUserDatasetIds()->sort()->values()->all());
@@ -304,13 +310,14 @@ class DatasetRepositoryTest extends TestCase
     {
         // Create 2 different fake responses, for 2 different users.
         $response1 = new Response(200, [], '{"datasets":[{"id":7,"name":"Cool dataset","dss_url":null,
-        "created_at":"2021-03-15T15:02:59.000000Z","updated_at":"2021-03-15T15:02:59.000000Z"},{"id":6,
+        "created_at":"2021-03-15T15:02:59.000000Z","updated_at":"2021-03-15T15:02:59.000000Z","modules":[]},{"id":6,
         "name":"Sjaak & Co","dss_url":null,"created_at":"2021-03-04T00:42:10.000000Z",
-        "updated_at":"2021-03-04T00:42:10.000000Z"},{"id":1,"name":"Spotify","dss_url":null,
-        "created_at":"2020-11-10T17:09:16.000000Z","updated_at":"2020-11-10T17:09:16.000000Z"}]}');
+        "updated_at":"2021-03-04T00:42:10.000000Z","modules":[]},{"id":1,"name":"Spotify","dss_url":null,
+        "created_at":"2020-11-10T17:09:16.000000Z","updated_at":"2020-11-10T17:09:16.000000Z","modules":[]}]}');
         $response2 = new Response(200, [], '{"datasets":[{"id":6,"name":"Sjaak & Co","dss_url":null,
-        "created_at":"2021-03-04T00:42:10.000000Z","updated_at":"2021-03-04T00:42:10.000000Z"},{"id":1,"name":"Spotify",
-        "dss_url":null,"created_at":"2020-11-10T17:09:16.000000Z","updated_at":"2020-11-10T17:09:16.000000Z"}]}');
+        "created_at":"2021-03-04T00:42:10.000000Z","updated_at":"2021-03-04T00:42:10.000000Z","modules":[]},{"id":1,
+        "name":"Spotify","dss_url":null,"created_at":"2020-11-10T17:09:16.000000Z",
+        "updated_at":"2020-11-10T17:09:16.000000Z","modules":[]}]}');
         $this->mockedResponses = [$response1, $response2];
 
         $this->actingAsAuth0User(['sub' => 'user1']);
@@ -345,15 +352,16 @@ class DatasetRepositoryTest extends TestCase
     {
         $respEmpty = new Response(200, [], '{"datasets": []}');
         $response1 = new Response(200, [], '{"datasets":[{"id":7,"name":"Cool dataset","dss_url":null,
-        "created_at":"2021-03-15T15:02:59.000000Z","updated_at":"2021-03-15T15:02:59.000000Z"},{"id":6,
+        "created_at":"2021-03-15T15:02:59.000000Z","updated_at":"2021-03-15T15:02:59.000000Z","modules":[]},{"id":6,
         "name":"Sjaak & Co","dss_url":null,"created_at":"2021-03-04T00:42:10.000000Z",
-        "updated_at":"2021-03-04T00:42:10.000000Z"},{"id":1,"name":"Spotify","dss_url":null,
-        "created_at":"2020-11-10T17:09:16.000000Z","updated_at":"2020-11-10T17:09:16.000000Z"}]}');
+        "updated_at":"2021-03-04T00:42:10.000000Z","modules":[]},{"id":1,"name":"Spotify","dss_url":null,
+        "created_at":"2020-11-10T17:09:16.000000Z","updated_at":"2020-11-10T17:09:16.000000Z","modules":[]}]}');
         $response2 = new Response(200, [], '{"datasets":[{"id":6,"name":"Sjaak & Co","dss_url":null,
-        "created_at":"2021-03-04T00:42:10.000000Z","updated_at":"2021-03-04T00:42:10.000000Z"},{"id":1,"name":"Spotify",
-        "dss_url":null,"created_at":"2020-11-10T17:09:16.000000Z","updated_at":"2020-11-10T17:09:16.000000Z"}]}');
+        "created_at":"2021-03-04T00:42:10.000000Z","updated_at":"2021-03-04T00:42:10.000000Z","modules":[]},{"id":1,
+        "name":"Spotify","dss_url":null,"created_at":"2020-11-10T17:09:16.000000Z",
+        "updated_at":"2020-11-10T17:09:16.000000Z","modules":[]}]}');
         $response3 = new Response(200, [], '{"datasets":[{"id":1,"name":"Spotify","dss_url":null,
-        "created_at":"2021-03-04T00:42:10.000000Z","updated_at":"2021-03-04T00:42:10.000000Z"}]}');
+        "created_at":"2021-03-04T00:42:10.000000Z","updated_at":"2021-03-04T00:42:10.000000Z","modules":[]}]}');
         $this->mockedResponses = [$response1, $respEmpty, $response2, $response3];
 
         $this->actingAsAuth0User(['sub' => 'user1']);
@@ -397,15 +405,16 @@ class DatasetRepositoryTest extends TestCase
     {
         $respEmpty = new Response(200, [], '{"datasets": []}');
         $response1 = new Response(200, [], '{"datasets":[{"id":7,"name":"Cool dataset","dss_url":null,
-        "created_at":"2021-03-15T15:02:59.000000Z","updated_at":"2021-03-15T15:02:59.000000Z"},{"id":6,
+        "created_at":"2021-03-15T15:02:59.000000Z","updated_at":"2021-03-15T15:02:59.000000Z","modules":[]},{"id":6,
         "name":"Sjaak & Co","dss_url":null,"created_at":"2021-03-04T00:42:10.000000Z",
-        "updated_at":"2021-03-04T00:42:10.000000Z"},{"id":1,"name":"Spotify","dss_url":null,
-        "created_at":"2020-11-10T17:09:16.000000Z","updated_at":"2020-11-10T17:09:16.000000Z"}]}');
+        "updated_at":"2021-03-04T00:42:10.000000Z","modules":[]},{"id":1,"name":"Spotify","dss_url":null,
+        "created_at":"2020-11-10T17:09:16.000000Z","updated_at":"2020-11-10T17:09:16.000000Z","modules":[]}]}');
         $response2 = new Response(200, [], '{"datasets":[{"id":6,"name":"Sjaak & Co","dss_url":null,
-        "created_at":"2021-03-04T00:42:10.000000Z","updated_at":"2021-03-04T00:42:10.000000Z"},{"id":1,"name":"Spotify",
-        "dss_url":null,"created_at":"2020-11-10T17:09:16.000000Z","updated_at":"2020-11-10T17:09:16.000000Z"}]}');
+        "created_at":"2021-03-04T00:42:10.000000Z","updated_at":"2021-03-04T00:42:10.000000Z","modules":[]},{"id":1,
+        "name":"Spotify","dss_url":null,"created_at":"2020-11-10T17:09:16.000000Z",
+        "updated_at":"2020-11-10T17:09:16.000000Z","modules":[]}]}');
         $response3 = new Response(200, [], '{"datasets":[{"id":1,"name":"Spotify","dss_url":null,
-        "created_at":"2021-03-04T00:42:10.000000Z","updated_at":"2021-03-04T00:42:10.000000Z"}]}');
+        "created_at":"2021-03-04T00:42:10.000000Z","updated_at":"2021-03-04T00:42:10.000000Z","modules":[]}]}');
         $this->mockedResponses = [$response1, $response1, $respEmpty, $respEmpty, $response2, $response2, $response3,
             $response3, $response1, $response1, $respEmpty, $respEmpty];
 


### PR DESCRIPTION
## Proposed changes
In the user tools, modules were added to the response. This PR adds the modules to the resources returned as well. It also adds support for faking the modules in the fake dataset repository. Or rather, it allows for faking any field of the datasets.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
### Unit testing
As usual

### Manual testing
Use the modules in a project, including testing for them with the fake repository.

## Further comments
This change is backward compatible.