### PR TITLE
Fix user retrieval from Auth0 Management API being limited to 50 users

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -694,22 +694,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.4.4",
+            "version": "7.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "e3ff079b22820c2029d4c2a87796b6a0b8716ad8"
+                "reference": "1dd98b0564cb3f6bd16ce683cb755f94c10fbd82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/e3ff079b22820c2029d4c2a87796b6a0b8716ad8",
-                "reference": "e3ff079b22820c2029d4c2a87796b6a0b8716ad8",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/1dd98b0564cb3f6bd16ce683cb755f94c10fbd82",
+                "reference": "1dd98b0564cb3f6bd16ce683cb755f94c10fbd82",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^1.5",
-                "guzzlehttp/psr7": "^1.8.3 || ^2.1",
+                "guzzlehttp/psr7": "^1.9 || ^2.4",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -798,7 +798,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.4.4"
+                "source": "https://github.com/guzzle/guzzle/tree/7.4.5"
             },
             "funding": [
                 {
@@ -814,7 +814,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-09T21:39:15+00:00"
+            "time": "2022-06-20T22:16:13+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -902,16 +902,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.3.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "83260bb50b8fc753c72d14dc1621a2dac31877ee"
+                "reference": "13388f00956b1503577598873fffb5ae994b5737"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/83260bb50b8fc753c72d14dc1621a2dac31877ee",
-                "reference": "83260bb50b8fc753c72d14dc1621a2dac31877ee",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/13388f00956b1503577598873fffb5ae994b5737",
+                "reference": "13388f00956b1503577598873fffb5ae994b5737",
                 "shasum": ""
             },
             "require": {
@@ -935,7 +935,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "2.4-dev"
                 }
             },
             "autoload": {
@@ -997,7 +997,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.3.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.4.0"
             },
             "funding": [
                 {
@@ -1013,20 +1013,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-09T08:26:02+00:00"
+            "time": "2022-06-20T21:43:11+00:00"
         },
         {
             "name": "laravel/framework",
-            "version": "v8.83.16",
+            "version": "v8.83.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "6be5abd144faf517879af7298e9d79f06f250f75"
+                "reference": "2cf142cd5100b02da248acad3988bdaba5635e16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/6be5abd144faf517879af7298e9d79f06f250f75",
-                "reference": "6be5abd144faf517879af7298e9d79f06f250f75",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/2cf142cd5100b02da248acad3988bdaba5635e16",
+                "reference": "2cf142cd5100b02da248acad3988bdaba5635e16",
                 "shasum": ""
             },
             "require": {
@@ -1186,7 +1186,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-06-07T15:09:06+00:00"
+            "time": "2022-06-21T14:38:31+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -3050,16 +3050,16 @@
         },
         {
             "name": "spatie/laravel-package-tools",
-            "version": "1.11.3",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-package-tools.git",
-                "reference": "baeb3df0ebb3a541394fdaf8cbe6115bf4034a59"
+                "reference": "9e6c0382553f1317c02f1ae0ee71c64821eb5af0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/baeb3df0ebb3a541394fdaf8cbe6115bf4034a59",
-                "reference": "baeb3df0ebb3a541394fdaf8cbe6115bf4034a59",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/9e6c0382553f1317c02f1ae0ee71c64821eb5af0",
+                "reference": "9e6c0382553f1317c02f1ae0ee71c64821eb5af0",
                 "shasum": ""
             },
             "require": {
@@ -3097,7 +3097,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-package-tools/issues",
-                "source": "https://github.com/spatie/laravel-package-tools/tree/1.11.3"
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.12.0"
             },
             "funding": [
                 {
@@ -3105,7 +3105,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-15T20:01:36+00:00"
+            "time": "2022-06-19T20:01:24+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -7381,16 +7381,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.7.12",
+            "version": "1.7.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "32f10779d9cd88a9cbd972ec611a4148a3cbbc7e"
+                "reference": "cd0202ea1b1fc6d1bbe156c6e2e18a03e0ff160a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/32f10779d9cd88a9cbd972ec611a4148a3cbbc7e",
-                "reference": "32f10779d9cd88a9cbd972ec611a4148a3cbbc7e",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/cd0202ea1b1fc6d1bbe156c6e2e18a03e0ff160a",
+                "reference": "cd0202ea1b1fc6d1bbe156c6e2e18a03e0ff160a",
                 "shasum": ""
             },
             "require": {
@@ -7416,7 +7416,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.7.12"
+                "source": "https://github.com/phpstan/phpstan/tree/1.7.15"
             },
             "funding": [
                 {
@@ -7436,7 +7436,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-09T12:39:36+00:00"
+            "time": "2022-06-20T08:29:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -7758,16 +7758,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.20",
+            "version": "9.5.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba"
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/12bc8879fb65aef2138b26fc633cb1e3620cffba",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e32b76be457de00e83213528f6bb37e2a38fcb1",
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1",
                 "shasum": ""
             },
             "require": {
@@ -7801,7 +7801,6 @@
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
-                "ext-pdo": "*",
                 "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
@@ -7845,7 +7844,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.20"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.21"
             },
             "funding": [
                 {
@@ -7857,7 +7856,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-01T12:37:26+00:00"
+            "time": "2022-06-19T12:14:25+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -9337,16 +9336,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.2",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
             "require": {
@@ -9389,7 +9388,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-12-12T21:44:58+00:00"
+            "time": "2022-06-18T07:21:10+00:00"
         },
         {
             "name": "symfony/config",

--- a/config/mrd-auth0.php
+++ b/config/mrd-auth0.php
@@ -17,8 +17,16 @@ return [
     | Time to live for cache entries stored by the package, in seconds. E.g. user info in Request and UserRepository.
     |
     */
-
     'cache_ttl' => env('AUTH0_CACHE_TTL', 300),
+
+    /*
+    |-------------------------------------------------------------------------------------------------------------------
+    | Chunk size
+    |-------------------------------------------------------------------------------------------------------------------
+    | Size of chunks when requesting values from the Auth0 management API. E.g. number of users in UserRepository.
+    |
+    */
+    'chunk_size' => env('AUTH0_CHUNK_SIZE', 50),
 
     /*
     |-------------------------------------------------------------------------------------------------------------------

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -47,7 +47,7 @@
     <rule ref="rulesets/controversial.xml"/>
     <rule ref="rulesets/design.xml/CouplingBetweenObjects">
         <properties>
-            <property name="maximum" value="15"/>
+            <property name="maximum" value="20"/>
         </properties>
     </rule>
     <rule ref="rulesets/naming.xml">

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -128,7 +128,7 @@ class UserRepository implements \Marketredesign\MrdAuth0Laravel\Contracts\UserRe
         $options = new RequestOptions(new FilteredRequest($fields, true));
 
         // Create cache key based on the query and fields.
-        $qValsString = implode(',', $uniqueQueryValues);
+        $qValsString = implode(',', $uniqueQueryValues->all());
         $fieldsString = implode(',', $fields ?? []);
         $cacheKey = 'auth0-users-all-' . hash('sha256', "$queryField:$qValsString;$fieldsString");
 

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -8,11 +8,15 @@ use Auth0\SDK\Contract\API\ManagementInterface;
 use Auth0\SDK\Utility\HttpResponse;
 use Auth0\SDK\Utility\Request\FilteredRequest;
 use Auth0\SDK\Utility\Request\RequestOptions;
+use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use JsonException;
+use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class UserRepository implements \Marketredesign\MrdAuth0Laravel\Contracts\UserRepository
@@ -44,6 +48,32 @@ class UserRepository implements \Marketredesign\MrdAuth0Laravel\Contracts\UserRe
     }
 
     /**
+     * Extract the content from an HTTP response as returned by the management API and parse as JSON.
+     * An HTTP exception is thrown when in case the request was not successful to begin with.
+     * An internal server error is generated when the JSON response could not be parsed.
+     *
+     * @param ResponseInterface $response
+     * @param int $expStatusCode The expected HTTP status code for the response to be considered successful.
+     * @param bool $associative When {@code true}, returned objects will be converted into associative arrays.
+     * @return mixed|void
+     */
+    private function decodeResponse(ResponseInterface $response, int $expStatusCode = 200, bool $associative = false)
+    {
+        // Throw exception if request was not successful.
+        if (!HttpResponse::wasSuccessful($response, $expStatusCode)) {
+            throw new HttpException($response->getStatusCode(), HttpResponse::getContent($response));
+        }
+
+        try {
+            // Return decoded response.
+            return json_decode(HttpResponse::getContent($response), $associative, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            Log::error('An error occurred while decoding Auth0 management response.', $e->getTrace());
+            abort(500, 'Error while decoding Auth0 management response.');
+        }
+    }
+
+    /**
      * @inheritDoc
      */
     public function get($id): ?object
@@ -57,13 +87,11 @@ class UserRepository implements \Marketredesign\MrdAuth0Laravel\Contracts\UserRe
         return Cache::remember($cacheKey, $this->cacheTTL, function () use ($id) {
             $response = $this->mgmtApi->users()->get($id);
 
-            if (HttpResponse::wasSuccessful($response)) {
-                return json_decode($response->getBody());
-            } elseif (HttpResponse::getStatusCode($response) == 404) {
+            if (HttpResponse::getStatusCode($response) == 404) {
                 return null;
-            } else {
-                throw new HttpException(HttpResponse::getStatusCode($response), HttpResponse::getContent($response));
             }
+
+            return $this->decodeResponse($response, 200, false);
         });
     }
 
@@ -77,8 +105,9 @@ class UserRepository implements \Marketredesign\MrdAuth0Laravel\Contracts\UserRe
         }
 
         $response = $this->mgmtApi->users()->delete($id);
-        if ($response->getStatusCode() != 204) {
-            throw new HttpException($response->getStatusCode());
+
+        if (!HttpResponse::wasSuccessful($response, 204)) {
+            throw new HttpException(HttpResponse::getStatusCode($response), HttpResponse::getContent($response));
         }
     }
 
@@ -96,12 +125,8 @@ class UserRepository implements \Marketredesign\MrdAuth0Laravel\Contracts\UserRe
             'password' => Hash::make(Str::random())
         ]);
 
-        if ($response->getStatusCode() != 201) {
-            throw new HttpException($response->getStatusCode());
-        }
-
         // body of response should be the newly created user object
-        return json_decode($response->getBody());
+        return $this->decodeResponse($response, 201);
     }
 
     /**
@@ -141,9 +166,9 @@ class UserRepository implements \Marketredesign\MrdAuth0Laravel\Contracts\UserRe
                 // Create Lucene query on user IDs.
                 $query = $queryField . ':("' . implode('" OR "', $qValsChunk->all()) . '")';
                 // Send request to Auth0 Management API.
-                $response = $this->mgmtApi->users()->getAll(['q' => $query], $options);
+                $response = $this->decodeResponse($this->mgmtApi->users()->getAll(['q' => $query], $options));
                 // Find users in the response and add to collection.
-                $users = $users->concat(json_decode($response->getBody()));
+                $users = $users->concat($response);
             }
 
             return collect($users)->keyBy($queryField);
@@ -159,25 +184,62 @@ class UserRepository implements \Marketredesign\MrdAuth0Laravel\Contracts\UserRe
     }
 
     /**
-     * @inheritdoc
-     */
-    public function getAllUsers(): Collection
-    {
-        $response = $this->mgmtApi->users()->getAll();
-        if ($response->getStatusCode() != 200) {
-            throw new HttpException($response->getStatusCode());
-        }
-
-        $users = json_decode($response->getBody());
-
-        return collect($users)->keyBy('user_id');
-    }
-
-    /**
      * @inheritDoc
      */
     public function getByEmails(Collection $emails, array $fields = null): Collection
     {
         return $this->getAll('email', $emails, $fields);
+    }
+
+    /**
+     * Calls the management API using {@code $callApi} as often as required and combines the results of the different
+     * pages into one collection.
+     *
+     * @param string $responseKey The key in the response from the management API containing the desired data.
+     * @param Closure $callApi Function that makes the actual calls to the management API. It must accept a param array
+     *  that is passed to the calls to the management API (containing the requested page etc).
+     * @return Collection
+     */
+    private function getFromMgmtPaginated(string $responseKey, Closure $callApi)
+    {
+        // Keep track of current page.
+        $page = 0;
+        // Function to create management API parameters including the requested page.
+        $createParams = fn($page) => ['include_totals' => true, 'page' => $page];
+        // Perform initial call to management API and decode the response.
+        $initialResponse = $this->decodeResponse($callApi($createParams($page)));
+        // Collect the desired results from the response.
+        $result = collect($initialResponse->$responseKey);
+        // Find page metadata in the response.
+        $total = $initialResponse->total;
+        $start = $initialResponse->start;
+        $length = $initialResponse->length;
+
+        // We keep calling the management API until there is no data left.
+        while ($start + $length < $total) {
+            $page++;
+            // Get new response for the next page.
+            $response = $this->decodeResponse($callApi($createParams($page)));
+            // Add the results of the new response to the collection.
+            $result = $result->concat($response->$responseKey);
+            // Update start and length values such that we know when we are finished.
+            $start = $response->start;
+            $length = $initialResponse->length;
+        }
+
+        // Finally, return the collection with the combined results.
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAllUsers(): Collection
+    {
+        return Cache::remember('auth0-all-users', $this->cacheTTL, function () {
+            $users = $this->getFromMgmtPaginated('users', fn($params) => $this->mgmtApi->users()->getAll($params));
+
+            return $users->keyBy('user_id');
+        });
     }
 }

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -49,7 +49,7 @@ class UserRepository implements \Marketredesign\MrdAuth0Laravel\Contracts\UserRe
 
     /**
      * Extract the content from an HTTP response as returned by the management API and parse as JSON.
-     * An HTTP exception is thrown when in case the request was not successful to begin with.
+     * An HTTP exception is thrown in case the request was not successful to begin with.
      * An internal server error is generated when the JSON response could not be parsed.
      *
      * @param ResponseInterface $response

--- a/tests/Feature/UserRepositoryTest.php
+++ b/tests/Feature/UserRepositoryTest.php
@@ -875,7 +875,7 @@ class UserRepositoryTest extends TestCase
     }
 
     /**
-     * Verifies that the underlying API is only called once for subsequent retrievals for the same email, multiple.
+     * Verifies that the underlying API is only called once for subsequent retrievals of all users.
      */
     public function testGetAllUsersCaching()
     {


### PR DESCRIPTION
## Proposed changes
Fixes the user retrieval from Auth0 Management API being limited to 50 users. 

Fixes [AB#209](https://dev.azure.com/jdokter/973dd796-5b61-4e4a-a52b-ab66f88cef8a/_workitems/edit/209).

## Types of changes

What types of changes does your code introduce to this repository?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
Explain here how to run your unit tests, and explain how to execute manual testing. 

### Unit testing
Added / updated.

### Manual testing
See marketredesign/user_tool#40.

## Further comments
The `getByIds` and `getByEmails` functions do not rely on Auth0's pagination response but, instead, simply make sure the IDs/emails are chunked before sending the management API requests. This, as the query parameter also has some size limit and an upper bound on the size of the responses for these functions can always be guaranteed. (assuming no 2 users with the same email can exist).
